### PR TITLE
Don't prompt for Git if Github Option is enabled

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -107,7 +107,7 @@ class NewCommand extends Command
             ) === 'Pest');
         }
 
-        if (! $input->getOption('git') && Process::fromShellCommandline('git --version')->run() === 0) {
+        if (! $input->getOption('git') && $input->getOption('github') === false && Process::fromShellCommandline('git --version')->run() === 0) {
             $input->setOption('git', confirm(label: 'Would you like to initialize a Git repository?'));
         }
     }


### PR DESCRIPTION
If you run `laravel new example-app --github` you are still getting asked if you want to initialize a Git Repository.

This PR removes the prompt if the Option `--github` is found.